### PR TITLE
IN-580 add sirius table to the json files

### DIFF
--- a/app/mapping_all_sheets.py
+++ b/app/mapping_all_sheets.py
@@ -44,6 +44,7 @@ class Mapping:
             "additional_columns",
             "is_pk",
             "data_type",
+            "table_name",
             # 'fk_children',
             "fk_parents",
             "is_complete",

--- a/app/template/mapping_template.json
+++ b/app/template/mapping_template.json
@@ -5,7 +5,8 @@
     "sirius_details": [
         "is_pk",
         "fk_parents",
-        "data_type"
+        "data_type",
+        "table_name"
     ],
     "transform_casrec": [
         "casrec_table",

--- a/mapping_definitions/addresses_migrated_mapping.json
+++ b/mapping_definitions/addresses_migrated_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "addresses_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "addresses_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "dict"
+            "data_type": "dict",
+            "table_name": "addresses_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "addresses_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "addresses_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "addresses_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "addresses_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/annual_report_lodging_details_mapping.json
+++ b/mapping_definitions/annual_report_lodging_details_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "annual_report_logs:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_lodging_details"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/annual_report_logs_mapping.json
+++ b/mapping_definitions/annual_report_logs_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_logs"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/annual_report_type_assignments_mapping.json
+++ b/mapping_definitions/annual_report_type_assignments_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "annual_report_type_assignments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_type_assignments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_type_assignments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "annual_report_type_assignments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "annual_report_logs:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "annual_report_type_assignments"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/assignablecomposite_caseitem_mapping.json
+++ b/mapping_definitions/assignablecomposite_caseitem_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "assignablecomposite_caseitem"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "assignablecomposite_caseitem"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/assignablecomposite_task_mapping.json
+++ b/mapping_definitions/assignablecomposite_task_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "assignablecomposite_task"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "tasks:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "assignablecomposite_task"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/assignee_teams_mapping.json
+++ b/mapping_definitions/assignee_teams_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "assignee_teams"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "assignee_teams"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/assignees_mapping.json
+++ b/mapping_definitions/assignees_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "dict"
+            "data_type": "dict",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "assignees"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/bond_providers_mapping.json
+++ b/mapping_definitions/bond_providers_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "bond_providers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "bond_providers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "bond_providers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "bond_providers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "bond_providers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "bond_providers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "bond_providers"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/bonds_mapping.json
+++ b/mapping_definitions/bonds_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "bonds"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "bonds"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "bonds"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "bonds"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "bonds"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "bonds"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "bonds"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "bond_providers:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "bonds"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",

--- a/mapping_definitions/case_timeline_mapping.json
+++ b/mapping_definitions/case_timeline_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "case_timeline"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "case_timeline"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "timeline_event:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "case_timeline"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/caseitem_document_mapping.json
+++ b/mapping_definitions/caseitem_document_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_document"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_document"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/caseitem_note_mapping.json
+++ b/mapping_definitions/caseitem_note_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_note"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "notes:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_note"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/caseitem_paymenttype_mapping.json
+++ b/mapping_definitions/caseitem_paymenttype_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_paymenttype"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "payments:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_paymenttype"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/caseitem_queue_mapping.json
+++ b/mapping_definitions/caseitem_queue_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_queue"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "queue_business_rules:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_queue"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/caseitem_task_mapping.json
+++ b/mapping_definitions/caseitem_task_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_task"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "tasks:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_task"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/caseitem_warning_mapping.json
+++ b/mapping_definitions/caseitem_warning_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_warning"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "warnings:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "caseitem_warning"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/cases_mapping.json
+++ b/mapping_definitions/cases_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -326,7 +342,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -346,7 +363,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -366,7 +384,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -386,7 +405,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -406,7 +426,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -426,7 +447,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -446,7 +468,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -466,7 +489,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -486,7 +510,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -506,7 +531,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -526,7 +552,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -546,7 +573,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -566,7 +594,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -586,7 +615,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -606,7 +636,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -626,7 +657,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -646,7 +678,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -666,7 +699,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -686,7 +720,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -706,7 +741,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -726,7 +762,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -746,7 +783,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -766,7 +804,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -786,7 +825,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -806,7 +846,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -826,7 +867,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -846,7 +888,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -866,7 +909,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -886,7 +930,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -906,7 +951,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -926,7 +972,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -946,7 +993,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -966,7 +1014,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -986,7 +1035,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -1006,7 +1056,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1026,7 +1077,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -1046,7 +1098,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -1066,7 +1119,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1086,7 +1140,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -1106,7 +1161,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1126,7 +1182,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -1146,7 +1203,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/cases_migrated_mapping.json
+++ b/mapping_definitions/cases_migrated_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "cases_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/client_addresses_mapping.json
+++ b/mapping_definitions/client_addresses_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "dict"
+            "data_type": "dict",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -72,7 +75,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -92,7 +96,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -112,7 +117,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -132,7 +138,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -152,7 +159,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -172,7 +180,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "addresses"
         },
         "transform_casrec": {
             "casrec_table": "PAT",

--- a/mapping_definitions/client_persons_mapping.json
+++ b/mapping_definitions/client_persons_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -326,7 +342,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -346,7 +363,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "Pat",
@@ -366,7 +384,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -386,7 +405,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -406,7 +426,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -426,7 +447,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -446,7 +468,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -466,7 +489,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -486,7 +510,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -506,7 +531,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -526,7 +552,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -546,7 +573,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -566,7 +594,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -586,7 +615,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -606,7 +636,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -626,7 +657,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -646,7 +678,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -666,7 +699,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -686,7 +720,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/client_phonenumbers_mapping.json
+++ b/mapping_definitions/client_phonenumbers_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/complaints_mapping.json
+++ b/mapping_definitions/complaints_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "complaints"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/courtfund_mapping.json
+++ b/mapping_definitions/courtfund_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "courtfund"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "float"
+            "data_type": "float",
+            "table_name": "courtfund"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "float"
+            "data_type": "float",
+            "table_name": "courtfund"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "courtfund"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "courtfund"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/death_notifications_mapping.json
+++ b/mapping_definitions/death_notifications_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "death_notifications"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/deputy_persons_mapping.json
+++ b/mapping_definitions/deputy_persons_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "DEPUTY",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "DEPUTY",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "DEPUTY",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "DEPUTY",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "DEPUTY",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -326,7 +342,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -346,7 +363,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -366,7 +384,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -386,7 +405,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -406,7 +426,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -426,7 +447,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -446,7 +468,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -466,7 +489,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -486,7 +510,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -506,7 +531,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -526,7 +552,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -546,7 +573,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -566,7 +594,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -586,7 +615,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -606,7 +636,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -626,7 +657,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -646,7 +678,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -666,7 +699,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -686,7 +720,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/deputy_phonenumbers_mapping.json
+++ b/mapping_definitions/deputy_phonenumbers_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "PAT",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "phonenumbers"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/document_pages_mapping.json
+++ b/mapping_definitions/document_pages_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "document_pages"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "document_pages"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "document_pages"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "document_pages"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/document_secondaryrecipient_mapping.json
+++ b/mapping_definitions/document_secondaryrecipient_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "document_secondaryrecipient"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "document_secondaryrecipient"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/documents_mapping.json
+++ b/mapping_definitions/documents_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -326,7 +342,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -346,7 +363,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -366,7 +384,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -386,7 +405,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -406,7 +426,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -426,7 +447,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -446,7 +468,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -466,7 +489,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -486,7 +510,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -506,7 +531,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -526,7 +552,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -546,7 +573,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -566,7 +594,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": ""
+            "data_type": "",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -586,7 +615,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": ""
+            "data_type": "",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -606,7 +636,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "dict"
+            "data_type": "dict",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -626,7 +657,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -646,7 +678,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -666,7 +699,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -686,7 +720,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "documents"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/epa_personnotifydonor_mapping.json
+++ b/mapping_definitions/epa_personnotifydonor_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "epa_personnotifydonor"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "epa_personnotifydonor"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/events_mapping.json
+++ b/mapping_definitions/events_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "dict"
+            "data_type": "dict",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": ""
+            "data_type": "",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "addresses:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "annual_report_logs:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -326,7 +342,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -346,7 +363,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "complaints:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -366,7 +384,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -386,7 +405,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "hold_period:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -406,7 +426,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "ingested_documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -426,7 +447,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "investigation:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -446,7 +468,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "notes:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -466,7 +489,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "document_pages:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -486,7 +510,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -506,7 +531,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "phonenumbers:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -526,7 +552,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "tasks:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -546,7 +573,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "uploads:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -566,7 +594,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "validation_check:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -586,7 +615,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "warnings:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -606,7 +636,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "events"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/fees_mapping.json
+++ b/mapping_definitions/fees_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "fees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "fees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "fees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "fees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "fees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "float"
+            "data_type": "float",
+            "table_name": "fees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "fees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "fees"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_counter_mapping.json
+++ b/mapping_definitions/finance_counter_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_counter"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_counter"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_counter"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_fee_mapping.json
+++ b/mapping_definitions/finance_fee_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_fee"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_fee"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_fee"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_fee"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "finance_fee"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_invoice_fee_range_mapping.json
+++ b/mapping_definitions/finance_invoice_fee_range_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_invoice_fee_range"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_invoice:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_invoice_fee_range"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_invoice_fee_range"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_invoice_fee_range"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_invoice_fee_range"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "finance_invoice_fee_range"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_invoice_mapping.json
+++ b/mapping_definitions/finance_invoice_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_person:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_remission_exemption:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_invoice"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_ledger_allocation_mapping.json
+++ b/mapping_definitions/finance_ledger_allocation_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_ledger:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_invoice:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger_allocation"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_ledger_mapping.json
+++ b/mapping_definitions/finance_ledger_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_person:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_remission_exemption:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_ledger"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_order_mapping.json
+++ b/mapping_definitions/finance_order_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_order"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_person:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_order"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_order"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_order"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_person_mapping.json
+++ b/mapping_definitions/finance_person_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_person"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_person"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_person"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_person"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_person"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_person"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_property_mapping.json
+++ b/mapping_definitions/finance_property_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_property"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_property"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_property"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_remission_exemption_mapping.json
+++ b/mapping_definitions/finance_remission_exemption_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_remission_exemption"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "finance_person:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_remission_exemption"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_remission_exemption"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_remission_exemption"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_remission_exemption"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "finance_remission_exemption"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_remission_exemption"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "finance_remission_exemption"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/finance_report_mapping.json
+++ b/mapping_definitions/finance_report_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_report"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_report"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "finance_report"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "finance_report"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "finance_report"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "finance_report"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/hold_period_mapping.json
+++ b/mapping_definitions/hold_period_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "hold_period"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "investigation:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "hold_period"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "hold_period"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "hold_period"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "hold_period"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "hold_period"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "hold_period"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/ingested_documents_mapping.json
+++ b/mapping_definitions/ingested_documents_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "ingested_documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "ingested_documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "ingested_documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "ingested_documents"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "ingested_documents"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/investigation_mapping.json
+++ b/mapping_definitions/investigation_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "investigation"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/lineitem_mapping.json
+++ b/mapping_definitions/lineitem_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "lineitem"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "lineitem"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "lineitem"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "float"
+            "data_type": "float",
+            "table_name": "lineitem"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/notes_mapping.json
+++ b/mapping_definitions/notes_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "uploads:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "notes"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/opgcore_doctrine_migrations_mapping.json
+++ b/mapping_definitions/opgcore_doctrine_migrations_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "opgcore_doctrine_migrations"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/order_courtfund_mapping.json
+++ b/mapping_definitions/order_courtfund_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "order_courtfund"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "courtfund:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "order_courtfund"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/order_deputy_mapping.json
+++ b/mapping_definitions/order_deputy_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "order_deputy"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/order_fees_mapping.json
+++ b/mapping_definitions/order_fees_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "order_fees"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "fees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "order_fees"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/pa_applicants_mapping.json
+++ b/mapping_definitions/pa_applicants_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "pa_applicants"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "pa_applicants"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/pa_certificate_provider_mapping.json
+++ b/mapping_definitions/pa_certificate_provider_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "pa_certificate_provider"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "pa_certificate_provider"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/pa_notified_persons_mapping.json
+++ b/mapping_definitions/pa_notified_persons_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "pa_notified_persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "pa_notified_persons"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/payments_mapping.json
+++ b/mapping_definitions/payments_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "payments"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/person_caseitem_mapping.json
+++ b/mapping_definitions/person_caseitem_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_caseitem"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_caseitem"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/person_document_mapping.json
+++ b/mapping_definitions/person_document_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_document"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "documents:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_document"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/person_note_mapping.json
+++ b/mapping_definitions/person_note_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_note"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "notes:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_note"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/person_personreference_mapping.json
+++ b/mapping_definitions/person_personreference_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_personreference"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "person_references:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_personreference"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/person_references_mapping.json
+++ b/mapping_definitions/person_references_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_references"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "person_references"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/person_task_mapping.json
+++ b/mapping_definitions/person_task_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_task"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "tasks:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_task"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/person_timeline_mapping.json
+++ b/mapping_definitions/person_timeline_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_timeline"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_timeline"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "timeline_event:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_timeline"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/person_warning_mapping.json
+++ b/mapping_definitions/person_warning_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_warning"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "warnings:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "person_warning"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/persons_mapping.json
+++ b/mapping_definitions/persons_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -326,7 +342,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -346,7 +363,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -366,7 +384,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -386,7 +405,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -406,7 +426,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -426,7 +447,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -446,7 +468,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -466,7 +489,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -486,7 +510,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -506,7 +531,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -526,7 +552,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -546,7 +573,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -566,7 +594,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -586,7 +615,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -606,7 +636,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -626,7 +657,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -646,7 +678,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -666,7 +699,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -686,7 +720,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -706,7 +741,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -726,7 +762,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -746,7 +783,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -766,7 +804,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -786,7 +825,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -806,7 +846,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -826,7 +867,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -846,7 +888,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -866,7 +909,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -886,7 +930,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -906,7 +951,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -926,7 +972,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -946,7 +993,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -966,7 +1014,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -986,7 +1035,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1006,7 +1056,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1026,7 +1077,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1046,7 +1098,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1066,7 +1119,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1086,7 +1140,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1106,7 +1161,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1126,7 +1182,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1146,7 +1203,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1166,7 +1224,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1186,7 +1245,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1206,7 +1266,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1226,7 +1287,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1246,7 +1308,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1266,7 +1329,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1286,7 +1350,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1306,7 +1371,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1326,7 +1392,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1346,7 +1413,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1366,7 +1434,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1386,7 +1455,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1406,7 +1476,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1426,7 +1497,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1446,7 +1518,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1466,7 +1539,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1486,7 +1560,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1506,7 +1581,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1526,7 +1602,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1546,7 +1623,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1566,7 +1644,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1586,7 +1665,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -1606,7 +1686,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/persons_migrated_mapping.json
+++ b/mapping_definitions/persons_migrated_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "persons_migrated"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/powerofattorney_person_mapping.json
+++ b/mapping_definitions/powerofattorney_person_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "powerofattorney_person"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "powerofattorney_person"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/queue_business_rules_mapping.json
+++ b/mapping_definitions/queue_business_rules_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "queue_business_rules"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/scheduled_events_mapping.json
+++ b/mapping_definitions/scheduled_events_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "scheduled_events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "scheduled_events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "dict"
+            "data_type": "dict",
+            "table_name": "scheduled_events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "scheduled_events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "scheduled_events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": ""
+            "data_type": "",
+            "table_name": "scheduled_events"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "scheduled_events"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_level_log_mapping.json
+++ b/mapping_definitions/supervision_level_log_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_level_log"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_level_log"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "supervision_level_log"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "supervision_level_log"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_level_log"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_level_log"
         },
         "transform_casrec": {
             "casrec_table": "ORDER",

--- a/mapping_definitions/supervision_reporting__account_mapping.json
+++ b/mapping_definitions/supervision_reporting__account_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__financial_information:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__accounts"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_reporting__assets_mapping.json
+++ b/mapping_definitions/supervision_reporting__assets_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__financial_information:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "Decimal"
+            "data_type": "Decimal",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -326,7 +342,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -346,7 +363,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -366,7 +384,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -386,7 +405,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -406,7 +426,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -426,7 +447,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -446,7 +468,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -466,7 +489,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__assets"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_reporting__debts_mapping.json
+++ b/mapping_definitions/supervision_reporting__debts_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__debts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__financial_information:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__debts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__debts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__debts"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__debts"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_reporting__decisio_mapping.json
+++ b/mapping_definitions/supervision_reporting__decisio_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__decisions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__welfare_information:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__decisions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__decisions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__decisions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__decisions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__decisions"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_reporting__financi_mapping.json
+++ b/mapping_definitions/supervision_reporting__financi_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__financial_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__reports:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__financial_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__financial_information"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_reporting__reports_mapping.json
+++ b/mapping_definitions/supervision_reporting__reports_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__reports"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_reporting__transac_mapping.json
+++ b/mapping_definitions/supervision_reporting__transac_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transactions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__financial_information:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transactions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transactions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__transactions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__transactions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transactions"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__transactions"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_reporting__transfe_mapping.json
+++ b/mapping_definitions/supervision_reporting__transfe_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transfers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__accounts:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transfers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__accounts:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transfers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transfers"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__transfers"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/supervision_reporting__welfare_mapping.json
+++ b/mapping_definitions/supervision_reporting__welfare_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "supervision_reporting__reports:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "supervision_reporting__welfare_information"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/tasks_mapping.json
+++ b/mapping_definitions/tasks_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "tasks"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/timeline_event_mapping.json
+++ b/mapping_definitions/timeline_event_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "timeline_event"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "timeline_event"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "timeline_event"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "timeline_event"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "dict"
+            "data_type": "dict",
+            "table_name": "timeline_event"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/uploads_mapping.json
+++ b/mapping_definitions/uploads_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "uploads"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "uploads"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "date"
+            "data_type": "date",
+            "table_name": "uploads"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "uploads"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/validation_check_mapping.json
+++ b/mapping_definitions/validation_check_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "validation_check"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "cases:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "validation_check"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "validation_check"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "validation_check"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "dict"
+            "data_type": "dict",
+            "table_name": "validation_check"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/visitor_mapping.json
+++ b/mapping_definitions/visitor_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "visitor"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visitor"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/visits_mapping.json
+++ b/mapping_definitions/visits_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "persons:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -166,7 +174,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -186,7 +195,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -206,7 +216,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -226,7 +237,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -246,7 +258,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -266,7 +279,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -286,7 +300,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -306,7 +321,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -326,7 +342,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -346,7 +363,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -366,7 +384,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "visits"
         },
         "transform_casrec": {
             "casrec_table": "",

--- a/mapping_definitions/warnings_mapping.json
+++ b/mapping_definitions/warnings_mapping.json
@@ -6,7 +6,8 @@
         "sirius_details": {
             "is_pk": true,
             "fk_parents": "",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "warnings"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -26,7 +27,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "warnings"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -46,7 +48,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "assignees:id",
-            "data_type": "int"
+            "data_type": "int",
+            "table_name": "warnings"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -66,7 +69,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "warnings"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -86,7 +90,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "str"
+            "data_type": "str",
+            "table_name": "warnings"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -106,7 +111,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "warnings"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -126,7 +132,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "datetime"
+            "data_type": "datetime",
+            "table_name": "warnings"
         },
         "transform_casrec": {
             "casrec_table": "",
@@ -146,7 +153,8 @@
         "sirius_details": {
             "is_pk": "",
             "fk_parents": "",
-            "data_type": "bool"
+            "data_type": "bool",
+            "table_name": "warnings"
         },
         "transform_casrec": {
             "casrec_table": "",


### PR DESCRIPTION
Both Jack & I are hardcoding the sirius tables in a couple of places, which ain't no good.
Behold! This is no longer necessary.

Most of the diff is the json files, the actual changes are in `app/template/mapping_template.json` and `app/mapping_all_sheets.py`